### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 9 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-formulas:
     runs-on: macos-latest


### PR DESCRIPTION
Potential fix for [https://github.com/lcmen/homebrew-extra/security/code-scanning/1](https://github.com/lcmen/homebrew-extra/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/update-formulas.yml` so the workflow documents and enforces least privilege.

Best fix without changing functionality:
- Define workflow-level permissions right after the `on:` section (before `jobs:`), so all jobs inherit it.
- Set:
  - `contents: write` (needed for branch/commit operations by `create-pull-request`)
  - `pull-requests: write` (needed to open/update PRs)
- This preserves existing behavior while explicitly constraining token scope to only required capabilities.

No imports/dependencies/methods are needed; this is a YAML config-only change in `.github/workflows/update-formulas.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
