### PR TITLE
Add lite version of libvips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Tap repository
+        run: brew tap lcmen/extra "$GITHUB_WORKSPACE"
+
+      - name: Audit formulas
+        run: >
+          brew audit --formula --strict
+          lcmen/extra/compartment
+          lcmen/extra/go-pty
+          lcmen/extra/libvips-lite
+          lcmen/extra/neovim_bin

--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -17,6 +17,7 @@ jobs:
         formula:
           - Formula/compartment.rb
           - Formula/go-pty.rb
+          - Formula/libvips-lite.rb
           - Formula/neovim_bin.rb
       fail-fast: false
     steps:

--- a/Formula/libvips-lite.rb
+++ b/Formula/libvips-lite.rb
@@ -75,6 +75,7 @@ class LibvipsLite < Formula
       -Draw=disabled
       -Drsvg=disabled
       -Dspng=disabled
+      -Dtiff=disabled
       -Duhdr=disabled
 
       -Dnsgif=true

--- a/Formula/libvips-lite.rb
+++ b/Formula/libvips-lite.rb
@@ -1,0 +1,106 @@
+class LibvipsLite < Formula
+  desc "Image processing library, stripped down for Rails image variants"
+  homepage "https://github.com/libvips/libvips"
+  version "8.18.2"
+  url "https://github.com/libvips/libvips/releases/download/v8.18.2/vips-8.18.2.tar.xz"
+  sha256 "a30d4aede16f1c2899c1a2241870f8a7409feafa38484bcdcdac113d6d6f8ff5"
+
+  depends_on "gettext" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+
+  depends_on "cgif"
+  depends_on "glib"
+  depends_on "libexif"
+  depends_on "libnsgif"
+  depends_on "libpng"
+  depends_on "little-cms2"
+  depends_on "mozjpeg"
+  depends_on "webp"
+
+  uses_from_macos "python" => :build
+  uses_from_macos "expat"
+  uses_from_macos "zlib"
+
+  conflicts_with "vips", because: "both install vips binaries, libvips, and vips pkg-config files"
+
+  def install
+    # mozjpeg needs to appear before libjpeg, otherwise libvips may pick up
+    # Apple's/system libjpeg or another libjpeg-compatible provider.
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["mozjpeg"].opt_lib/"pkgconfig"
+
+    args = %w[
+      -Ddeprecated=true
+      -Dexamples=false
+      -Dcplusplus=false
+      -Ddocs=false
+      -Dcpp-docs=false
+      -Dintrospection=disabled
+      -Dvapi=false
+      -Dmodules=disabled
+
+      -Djpeg=enabled
+      -Dpng=enabled
+      -Dwebp=enabled
+      -Dcgif=enabled
+      -Dexif=enabled
+      -Dlcms=enabled
+      -Dzlib=enabled
+
+      -Darchive=disabled
+      -Dcfitsio=disabled
+      -Dfftw=disabled
+      -Dfontconfig=disabled
+      -Dheif=disabled
+      -Dheif-module=disabled
+      -Dhighway=disabled
+      -Dimagequant=disabled
+      -Djpeg-xl=disabled
+      -Djpeg-xl-module=disabled
+      -Dmagick=disabled
+      -Dmagick-module=disabled
+      -Dmatio=disabled
+      -Dnifti=disabled
+      -Dopenexr=disabled
+      -Dopenjpeg=disabled
+      -Dopenslide=disabled
+      -Dopenslide-module=disabled
+      -Dorc=disabled
+      -Dpangocairo=disabled
+      -Dpdfium=disabled
+      -Dpoppler=disabled
+      -Dpoppler-module=disabled
+      -Dquantizr=disabled
+      -Draw=disabled
+      -Drsvg=disabled
+      -Dspng=disabled
+      -Duhdr=disabled
+
+      -Dnsgif=true
+      -Dppm=false
+      -Danalyze=false
+      -Dradiance=false
+    ]
+
+    system "meson", "setup", "build", *std_meson_args, *args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    system bin/"vips", "-l"
+
+    input = test_fixtures("test.png")
+
+    assert_equal "8", shell_output("#{bin}/vipsheader -f width #{input}").chomp
+
+    system bin/"vips", "resize", input, testpath/"resized.jpg", "0.5"
+    assert_equal "4", shell_output("#{bin}/vipsheader -f width #{testpath}/resized.jpg").chomp
+
+    system bin/"vips", "copy", input, testpath/"test.webp"
+    assert_equal "8", shell_output("#{bin}/vipsheader -f width #{testpath}/test.webp").chomp
+
+    system "pkgconf", "--print-errors", "vips"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ Or `brew tap lcmen/extra` and then `brew install <formula>`.
 
 * `compartment` - Docker-based CLI tool for managing local development services
 * `go-pty` - Terminal multiplexer for Go applications
+* `libvips-lite` - Image processing library, stripped down for Rails image variants
 * `neovim_bin` - Neovim binary without any dependencies


### PR DESCRIPTION
This formula provides a stripped-down version of the LibVips image processing library, suitable for Rails image variants. It includes dependencies and configuration options for building and testing.